### PR TITLE
Add back thematic_canonical_url function, to throw deprecated error

### DIFF
--- a/library/legacy/deprecated.php
+++ b/library/legacy/deprecated.php
@@ -58,6 +58,14 @@ function thematic_show_commentreply() {
             wp_enqueue_script('comment-reply'); 
 }
 
+/**
+ * thematic_canonical_url is no longer necessary because the functionality has been included in WordPress core since 2.9.0
+ *
+ * @deprecated 1.0
+ */
+function thematic_canonical_url() {
+	_deprecated_function( __FUNCTION__, '1.0' );
+}
 
 /**
  * Get the page number for title tag


### PR DESCRIPTION
I just updated to 1.0.2 from 0.9.7, and got a 'call to undefined function' error.

I understand why the function is no longer necessary in Thematic, but given that thematic has been 'sleeping' for a while, and so there will no doubt be lots of people updating from very old versions, wouldn't it be better to reinstate the function and throw a deprecated error?
