### PR TITLE
add filter for the main layouts

### DIFF
--- a/library/extensions/customizer.php
+++ b/library/extensions/customizer.php
@@ -62,15 +62,17 @@ function thematic_customize_register( $wp_customize ) {
 			'type'   => 'option',
 		) );
 		
+		$possible_layouts = thematic_available_theme_layouts();
+		$available_layouts = array();
+		foreach( $possible_layouts as $layout) {
+			$available_layouts[ $layout['slug'] ] = $layout['title'];
+		}
+
 		$wp_customize->add_control( 'thematic_layout_control', array(
 			'type'  => 'radio',
 			'label'  => __( 'Theme layout', 'thematic' ),
 			'section' => 'thematic_layout',
-			'choices' => array(
-				'right-sidebar' => __( 'Right Sidebar', 'thematic' ),
-				'left-sidebar'  => __( 'Left Sidebar', 'thematic' ),
-				'three-columns' => __( 'Three columns', 'thematic' )
-			),
+			'choices' => $available_layouts,
 			'settings' => 'thematic_theme_opt[layout]'
 		) );
 	}

--- a/library/extensions/dynamic-classes.php
+++ b/library/extensions/dynamic-classes.php
@@ -7,6 +7,33 @@
  */
 
 
+/**
+ * Specifies the available layouts for the theme
+ *
+ * @since 2.0
+ *
+ * @return array $layouts
+ */
+function thematic_available_theme_layouts() {
+	$layouts = array(
+		'left-sidebar' => array(
+			'slug'  => 'left-sidebar',
+			'title' => __( 'Left Sidebar', 'thematic' )
+		),
+		'right-sidebar' => array(
+			'slug' => 'right-sidebar',
+			'title' => __( 'Right Sidebar', 'thematic' )
+		),
+		'three-columns' => array(
+			'slug' => 'three-columns',
+			'title' => __( 'Three columns', 'thematic' )
+		)
+	);
+
+	return apply_filters( 'thematic_available_theme_layouts', $layouts );
+}
+
+
 if ( function_exists( 'childtheme_override_body_class' ) )  {
 	/**
 	 * @ignore

--- a/library/extensions/dynamic-classes.php
+++ b/library/extensions/dynamic-classes.php
@@ -34,6 +34,24 @@ function thematic_available_theme_layouts() {
 }
 
 
+/**
+ * Create a simple array of the available layout strings
+ *
+ * @since 2.0
+ *
+ * @return array $layouts
+ */
+function thematic_available_layout_slugs() {
+	$possible_layouts = thematic_available_theme_layouts();
+	$available_layouts = array();
+	foreach( $possible_layouts as $layout) {
+		$available_layouts[] = $layout['slug'];
+	}
+
+	return $available_layouts();
+}
+
+
 if ( function_exists( 'childtheme_override_body_class' ) )  {
 	/**
 	 * @ignore
@@ -49,12 +67,8 @@ if ( function_exists( 'childtheme_override_body_class' ) )  {
 	 */
 	function thematic_body_class( $classes ) {
 		$current_layout = thematic_get_theme_opt( 'layout' );
-		
-		$possible_layouts = thematic_available_theme_layouts();
-		$available_layouts = array();
-		foreach( $possible_layouts as $layout) {
-			$available_layouts[] = $layout['slug'];
-		}
+
+		$available_layouts = thematic_available_layout_slugs();
 
 		/**
 		 * Filter to control the layout

--- a/library/extensions/dynamic-classes.php
+++ b/library/extensions/dynamic-classes.php
@@ -41,7 +41,7 @@ if ( function_exists( 'childtheme_override_body_class' ) )  {
 		if( in_array( $current_layout, $available_layouts ) ) {
 			$classes[] = $current_layout;
 		} else {
-			$classes[] = apply_filters( 'thematic_default_theme_layout', 'right-sidebar' );
+			$classes[] = thematic_default_theme_layout();
 		}
 		
 		if ( is_page_template( 'template-page-fullwidth.php' ) ) {

--- a/library/extensions/dynamic-classes.php
+++ b/library/extensions/dynamic-classes.php
@@ -7,51 +7,6 @@
  */
 
 
-/**
- * Specifies the available layouts for the theme
- *
- * @since 2.0
- *
- * @return array $layouts
- */
-function thematic_available_theme_layouts() {
-	$layouts = array(
-		'left-sidebar' => array(
-			'slug'  => 'left-sidebar',
-			'title' => __( 'Left Sidebar', 'thematic' )
-		),
-		'right-sidebar' => array(
-			'slug' => 'right-sidebar',
-			'title' => __( 'Right Sidebar', 'thematic' )
-		),
-		'three-columns' => array(
-			'slug' => 'three-columns',
-			'title' => __( 'Three columns', 'thematic' )
-		)
-	);
-
-	return apply_filters( 'thematic_available_theme_layouts', $layouts );
-}
-
-
-/**
- * Create a simple array of the available layout strings
- *
- * @since 2.0
- *
- * @return array $layouts
- */
-function thematic_available_layout_slugs() {
-	$possible_layouts = thematic_available_theme_layouts();
-	$available_layouts = array();
-	foreach( $possible_layouts as $layout) {
-		$available_layouts[] = $layout['slug'];
-	}
-
-	return $available_layouts();
-}
-
-
 if ( function_exists( 'childtheme_override_body_class' ) )  {
 	/**
 	 * @ignore

--- a/library/extensions/dynamic-classes.php
+++ b/library/extensions/dynamic-classes.php
@@ -50,6 +50,12 @@ if ( function_exists( 'childtheme_override_body_class' ) )  {
 	function thematic_body_class( $classes ) {
 		$current_layout = thematic_get_theme_opt( 'layout' );
 		
+		$possible_layouts = thematic_available_theme_layouts();
+		$available_layouts = array();
+		foreach( $possible_layouts as $layout) {
+			$available_layouts[] = $layout['slug'];
+		}
+
 		/**
 		 * Filter to control the layout
 		 * 
@@ -61,18 +67,12 @@ if ( function_exists( 'childtheme_override_body_class' ) )  {
 		 * 
 		 * @param string $current_layout
 		 */
-		$current_layout = apply_filters( 'thematic_theme_layout', $current_layout );
+		$current_layout = apply_filters( 'thematic_current_theme_layout', $current_layout );
 		
-		switch( $current_layout ) {
-			case 'left-sidebar':
-				$classes[] = 'left-sidebar';
-				break;
-			case 'three-columns':
-				$classes[] = 'three-columns';
-				break;
-			default:
-				$classes[] = 'right-sidebar';
-				break;
+		if( in_array( $current_layout, $available_layouts ) ) {
+			$classes[] = $current_layout;
+		} else {
+			$classes[] = 'right-sidebar';
 		}
 		
 		if ( is_page_template( 'template-page-fullwidth.php' ) ) {

--- a/library/extensions/dynamic-classes.php
+++ b/library/extensions/dynamic-classes.php
@@ -72,7 +72,7 @@ if ( function_exists( 'childtheme_override_body_class' ) )  {
 		if( in_array( $current_layout, $available_layouts ) ) {
 			$classes[] = $current_layout;
 		} else {
-			$classes[] = 'right-sidebar';
+			$classes[] = apply_filters( 'thematic_default_theme_layout', 'right-sidebar' );
 		}
 		
 		if ( is_page_template( 'template-page-fullwidth.php' ) ) {

--- a/library/extensions/helpers.php
+++ b/library/extensions/helpers.php
@@ -193,4 +193,22 @@ function thematic_available_layout_slugs() {
 	return $available_layouts;
 }
 
+
+/**
+ * Decide the default layout of the theme
+ *
+ * @since 2.0
+ *
+ * @return string $default_layout
+ */
+function thematic_default_theme_layout() {
+	$thematic_default_layout = apply_filters( 'thematic_default_theme_layout', 'right-sidebar' );
+
+	// check that the filtered layout is a valid layout
+	if ( !in_array( $thematic_default_layout, thematic_available_layout_slugs() ) ) {
+		$thematic_default_layout = 'right-sidebar';
+	}
+
+	return $thematic_default_layout;
+}
 ?>

--- a/library/extensions/helpers.php
+++ b/library/extensions/helpers.php
@@ -148,4 +148,49 @@ function thematic_is_legacy_xhtml() {
 	return false;
 }
 
+
+/**
+ * Specifies the available layouts for the theme
+ *
+ * @since 2.0
+ *
+ * @return array $layouts
+ */
+function thematic_available_theme_layouts() {
+	$layouts = array(
+		'left-sidebar' => array(
+			'slug'  => 'left-sidebar',
+			'title' => __( 'Left Sidebar', 'thematic' )
+		),
+		'right-sidebar' => array(
+			'slug' => 'right-sidebar',
+			'title' => __( 'Right Sidebar', 'thematic' )
+		),
+		'three-columns' => array(
+			'slug' => 'three-columns',
+			'title' => __( 'Three columns', 'thematic' )
+		)
+	);
+
+	return apply_filters( 'thematic_available_theme_layouts', $layouts );
+}
+
+
+/**
+ * Create a simple array of the available layout strings
+ *
+ * @since 2.0
+ *
+ * @return array $layouts
+ */
+function thematic_available_layout_slugs() {
+	$possible_layouts = thematic_available_theme_layouts();
+	$available_layouts = array();
+	foreach( $possible_layouts as $layout) {
+		$available_layouts[] = $layout['slug'];
+	}
+
+	return $available_layouts();
+}
+
 ?>

--- a/library/extensions/helpers.php
+++ b/library/extensions/helpers.php
@@ -190,7 +190,7 @@ function thematic_available_layout_slugs() {
 		$available_layouts[] = $layout['slug'];
 	}
 
-	return $available_layouts();
+	return $available_layouts;
 }
 
 ?>

--- a/library/extensions/theme-options.php
+++ b/library/extensions/theme-options.php
@@ -402,8 +402,8 @@ if (function_exists('childtheme_override_validate_opt')) {
 		if( isset( $input['layout'] ) ) {
 			$available_layouts = thematic_available_layout_slugs();
 
-			if( in_array( $current_layout, $available_layouts ) ) {
-				$output['layout'] = $current_layout;
+			if( in_array( $input['layout'], $available_layouts ) ) {
+				$output['layout'] = $input['layout'];
 			} else {
 				$output['layout'] = thematic_default_theme_layout();
 			}

--- a/library/extensions/theme-options.php
+++ b/library/extensions/theme-options.php
@@ -400,11 +400,7 @@ if (function_exists('childtheme_override_validate_opt')) {
 		
 		// Check and set layout
 		if( isset( $input['layout'] ) ) {
-			$possible_layouts = thematic_available_theme_layouts();
-			$available_layouts = array();
-			foreach( $possible_layouts as $layout) {
-				$available_layouts[] = $layout['slug'];
-			}
+			$available_layouts = thematic_available_layout_slugs();
 
 			if( in_array( $current_layout, $available_layouts ) ) {
 				$output['layout'] = $current_layout;

--- a/library/extensions/theme-options.php
+++ b/library/extensions/theme-options.php
@@ -51,7 +51,7 @@ if (function_exists('childtheme_override_opt_init')) {
 				'footer_txt' 	=> 'Powered by [wp-link]. Built on the [theme-link].',
 				'del_legacy_opt'=> 0, // 0 = not checked 1 = check
 				'legacy_xhtml'	=> 1,  // 0 = not checked 1 = check
-				'layout'        => apply_filters( 'thematic_default_theme_layout', 'right-sidebar' )
+				'layout'        => thematic_default_theme_layout()
 			);
 			update_option( 'thematic_theme_opt', $thematic_upgrade_opt );
 		}
@@ -172,7 +172,7 @@ function thematic_default_opt() {
 		'footer_txt' 	=> 'Powered by [wp-link]. Built on the [theme-link].',
 		'del_legacy_opt'=> 0, // 0 = not checked 1 = check
 		'legacy_xhtml'	=> 0,  // 0 = not checked 1 = check
-		'layout'        => apply_filters( 'thematic_default_theme_layout', 'right-sidebar' )
+		'layout'        => thematic_default_theme_layout()
 	);
 
 	return apply_filters( 'thematic_theme_default_opt', $thematic_default_opt );
@@ -405,7 +405,7 @@ if (function_exists('childtheme_override_validate_opt')) {
 			if( in_array( $current_layout, $available_layouts ) ) {
 				$output['layout'] = $current_layout;
 			} else {
-				$output['layout'] = apply_filters( 'thematic_default_theme_layout', 'right-sidebar' );
+				$output['layout'] = thematic_default_theme_layout();
 			}
 		}
  	   

--- a/library/extensions/theme-options.php
+++ b/library/extensions/theme-options.php
@@ -400,16 +400,16 @@ if (function_exists('childtheme_override_validate_opt')) {
 		
 		// Check and set layout
 		if( isset( $input['layout'] ) ) {
-			switch( $input['layout'] ) {
-				case 'left-sidebar':
-					$output['layout'] = 'left-sidebar';
-					break;
-				case 'three-columns':
-					$output['layout'] = 'three-columns';
-					break;
-				default:
-					$output['layout'] = 'right-sidebar';
-					break;
+			$possible_layouts = thematic_available_theme_layouts();
+			$available_layouts = array();
+			foreach( $possible_layouts as $layout) {
+				$available_layouts[] = $layout['slug'];
+			}
+
+			if( in_array( $current_layout, $available_layouts ) ) {
+				$output['layout'] = $current_layout;
+			} else {
+				$output['layout'] = 'right-sidebar';
 			}
 		}
  	   

--- a/library/extensions/theme-options.php
+++ b/library/extensions/theme-options.php
@@ -51,7 +51,7 @@ if (function_exists('childtheme_override_opt_init')) {
 				'footer_txt' 	=> 'Powered by [wp-link]. Built on the [theme-link].',
 				'del_legacy_opt'=> 0, // 0 = not checked 1 = check
 				'legacy_xhtml'	=> 1,  // 0 = not checked 1 = check
-				'layout'        => 'right-sidebar'
+				'layout'        => apply_filters( 'thematic_default_theme_layout', 'right-sidebar' )
 			);
 			update_option( 'thematic_theme_opt', $thematic_upgrade_opt );
 		}
@@ -172,7 +172,7 @@ function thematic_default_opt() {
 		'footer_txt' 	=> 'Powered by [wp-link]. Built on the [theme-link].',
 		'del_legacy_opt'=> 0, // 0 = not checked 1 = check
 		'legacy_xhtml'	=> 0,  // 0 = not checked 1 = check
-		'layout'        => 'right-sidebar'
+		'layout'        => apply_filters( 'thematic_default_theme_layout', 'right-sidebar' )
 	);
 
 	return apply_filters( 'thematic_theme_default_opt', $thematic_default_opt );
@@ -409,7 +409,7 @@ if (function_exists('childtheme_override_validate_opt')) {
 			if( in_array( $current_layout, $available_layouts ) ) {
 				$output['layout'] = $current_layout;
 			} else {
-				$output['layout'] = 'right-sidebar';
+				$output['layout'] = apply_filters( 'thematic_default_theme_layout', 'right-sidebar' );
 			}
 		}
  	   

--- a/library/tests/test-dynamic-classes.php
+++ b/library/tests/test-dynamic-classes.php
@@ -15,17 +15,46 @@ class TestDynamicClasses extends Thematic_UnitTestCase {
 		$this->assertContains( 'right-sidebar', $body_classes );	
 	}
 	
-	function test_thematic_body_class_filter_layout() {
-		add_filter( 'thematic_theme_layout', array( $this, 'switch_layout' ) );
+	function test_thematic_filter_current_theme_layout() {
+		add_filter( 'thematic_current_theme_layout', array( $this, 'switch_layout' ) );
 		
-		$current_layout = apply_filters( 'thematic_theme_layout', '' );
+		$current_layout = apply_filters( 'thematic_current_theme_layout', '' );
 		
 		$body_classes = thematic_body_class( array() );
 		$this->assertContains( 'left-sidebar', $body_classes );	
 	}
 
+	function test_thematic_add_available_layout() {
+		add_filter( 'thematic_available_theme_layouts', array( $this, 'add_layout' ) );
+
+		$available_layouts = apply_filters( 'thematic_available_theme_layouts', thematic_available_theme_layouts() );
+
+		$this->assertArrayHasKey( 'half-sidebar', $available_layouts );
+	}
+
+	function test_thematic_remove_available_layout() {
+		add_filter( 'thematic_available_theme_layouts', array( $this, 'remove_layout' ) );
+
+		$available_layouts = apply_filters( 'thematic_available_theme_layouts', thematic_available_theme_layouts() );
+
+		$this->assertArrayNotHasKey( 'right-sidebar', $available_layouts );
+	}
+
 	function switch_layout( $layout ) {
 		return 'left-sidebar';
+	}
+
+	function add_layout( $layouts ) {
+		$layouts['half-sidebar'] = array(
+			'slug' => 'half-sidebar',
+			'title' => 'Half Sidebar'
+		);
+		return $layouts;
+	}
+
+	function remove_layout( $layouts ) {
+		unset( $layouts['right-sidebar'] );
+		return $layouts;
 	}
 
 }

--- a/library/tests/test-dynamic-classes.php
+++ b/library/tests/test-dynamic-classes.php
@@ -10,10 +10,18 @@
  */
 class TestDynamicClasses extends Thematic_UnitTestCase {
 
+	function tearDown() {
+		remove_filter( 'thematic_default_theme_layout', array( $this, 'switch_layout' ) );
+
+		parent::tearDown();
+	}
+
+
 	function test_thematic_body_class_layout() {
 		$body_classes = thematic_body_class( array() );
 		$this->assertContains( 'right-sidebar', $body_classes );	
 	}
+
 	
 	function test_thematic_filter_current_theme_layout() {
 		add_filter( 'thematic_current_theme_layout', array( $this, 'switch_layout' ) );
@@ -24,6 +32,7 @@ class TestDynamicClasses extends Thematic_UnitTestCase {
 		$this->assertContains( 'left-sidebar', $body_classes );	
 	}
 
+
 	function test_thematic_add_available_layout() {
 		add_filter( 'thematic_available_theme_layouts', array( $this, 'add_layout' ) );
 
@@ -31,6 +40,7 @@ class TestDynamicClasses extends Thematic_UnitTestCase {
 
 		$this->assertArrayHasKey( 'half-sidebar', $available_layouts );
 	}
+
 
 	function test_thematic_remove_available_layout() {
 		add_filter( 'thematic_available_theme_layouts', array( $this, 'remove_layout' ) );
@@ -40,9 +50,41 @@ class TestDynamicClasses extends Thematic_UnitTestCase {
 		$this->assertArrayNotHasKey( 'right-sidebar', $available_layouts );
 	}
 
+
+	function test_thematic_unavailable_layout() {
+		add_filter( 'thematic_current_theme_layout', array( $this, 'unavailable_layout' ) );
+
+		$body_classes = thematic_body_class( array() );
+		$this->assertNotContains( 'wacko', $body_classes );
+		$this->assertContains( 'right-sidebar', $body_classes );
+	}
+
+
+	function test_thematic_change_default_layout() {
+		add_filter( 'thematic_default_theme_layout', array( $this, 'switch_layout' ) );
+
+		$this->theme_options['layout'] = apply_filters( 'thematic_default_theme_layout', $this->theme_options['layout'] );
+
+		$this->assertEquals( $this->theme_options['layout'], 'left-sidebar' );
+	}
+
+
+	function test_thematic_unavailable_layout_different_default() {
+		add_filter( 'thematic_current_theme_layout', array( $this, 'unavailable_layout' ) );
+
+		add_filter( 'thematic_default_theme_layout', array( $this, 'switch_layout' ) );
+		$this->theme_options['layout'] = apply_filters( 'thematic_default_theme_layout', $this->theme_options['layout'] );
+
+		$body_classes = thematic_body_class( array() );
+		$this->assertNotContains( 'wacko', $body_classes );
+		$this->assertContains( 'left-sidebar', $body_classes );
+	}
+
+
 	function switch_layout( $layout ) {
 		return 'left-sidebar';
 	}
+
 
 	function add_layout( $layouts ) {
 		$layouts['half-sidebar'] = array(
@@ -52,9 +94,15 @@ class TestDynamicClasses extends Thematic_UnitTestCase {
 		return $layouts;
 	}
 
+
 	function remove_layout( $layouts ) {
 		unset( $layouts['right-sidebar'] );
 		return $layouts;
+	}
+
+
+	function unavailable_layout() {
+		return 'wacko';
 	}
 
 }


### PR DESCRIPTION
Enable child themes to add layouts via filter. Simply make the layouts an array that gets used in body_class, theme customizer and thematic_validate_opt().

The css for the layouts will be up to the child theme of course.
