### PR TITLE
legacy mode breaks any page tempates in the child theme (they never load...

### DIFF
--- a/library/legacy/legacy.php
+++ b/library/legacy/legacy.php
@@ -15,7 +15,7 @@ function thematic_load_legacy_template_files( $template ) {
 	if( is_attachment() )
 		$template = THEMATIC_LIB . '/legacy/legacy-attachment.php';
 		
-	if( is_page() )
+	if( is_page() && ! is_page_template() )
 		$template = THEMATIC_LIB . '/legacy/legacy-page.php';
 		
 	if( is_page_template( 'links.php' ) )


### PR DESCRIPTION
.../are redirected to use the legacy-page.php)

To continue our twitter convo: I would agree that I don't like the checkbox for legacy mode... and I definitely didn't like that it was automatically on, but maybe that's b/c it just drove me crazy for the last 3 hours. 

I prefer `add_theme_support()` even if that is maybe a touch harder for total non-coders. 
