### PR TITLE
Feature/html5 theme support

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -101,7 +101,7 @@ if ( function_exists('childtheme_override_theme_setup') ) {
 		
 		// Load overrides to activate the old xhtml markup if set
 		if ( !is_admin() && thematic_is_legacy_xhtml() ) {
-			add_theme_support( 'thematic_legacy' );
+			add_theme_support( 'thematic_xhtml' );
 			require_once ( THEMATIC_LIB . '/legacy/legacy.php' );
 		}
 		

--- a/functions.php
+++ b/functions.php
@@ -101,7 +101,6 @@ if ( function_exists('childtheme_override_theme_setup') ) {
 		
 		// Load overrides to activate the old xhtml markup if set
 		if ( !is_admin() && thematic_is_legacy_xhtml() ) {
-			add_theme_support( 'thematic_xhtml' );
 			require_once ( THEMATIC_LIB . '/legacy/legacy.php' );
 		}
 		

--- a/library/extensions/helpers.php
+++ b/library/extensions/helpers.php
@@ -142,7 +142,7 @@ function thematic_is_custom_post_type() {
  * @return bool
  */
 function thematic_is_legacy_xhtml() {
-	if ( thematic_get_theme_opt( 'legacy_xhtml' ) === 1 || current_theme_supports( 'thematic_legacy' ) ) {
+	if ( thematic_get_theme_opt( 'legacy_xhtml' ) === 1 || current_theme_supports( 'thematic_xhtml' ) ) {
 		return true;
 	}
 		

--- a/library/extensions/helpers.php
+++ b/library/extensions/helpers.php
@@ -137,16 +137,28 @@ function thematic_is_custom_post_type() {
 }
 
 /**
- * Check if the option to use legacy xhtml is set
- * 
- * @return bool
+ * Determine if we want to use html5 or xhtml markup
+ *
+ * @return bool True for xhtml, false for html5 markup
  */
 function thematic_is_legacy_xhtml() {
-	if ( thematic_get_theme_opt( 'legacy_xhtml' ) === 1 || current_theme_supports( 'thematic_xhtml' ) ) {
+
+	// Child themes can set html5 markup
+	if ( current_theme_supports( 'thematic_html5' ) ) {
+		return false;
+	}
+
+	// Child themes can opt to use xhtml
+	if ( current_theme_supports( 'thematic_xhtml' ) ) {
 		return true;
 	}
-		
-	return false;
+
+	// New 2.0 installations haven't set the legacy mode
+	if ( 0 == thematic_get_theme_opt( 'legacy_xhtml' ) ) {
+		return false;
+	}
+
+	return true;
 }
 
 

--- a/library/extensions/theme-options.php
+++ b/library/extensions/theme-options.php
@@ -60,7 +60,7 @@ if (function_exists('childtheme_override_opt_init')) {
 		 * 
 		 * @param bool true
 		 */
-		if( apply_filters( 'thematic_show_legacymode_checkbox', true ) ) {
+		if( apply_filters( 'thematic_show_legacymode_checkbox', false ) ) {
 			// show check box option for restoring legacy xtml1.0 doctype and compatible markup
 			add_settings_field ('thematic_legacy_xhtml_opt', __('Restore Legacy XHTML1.0 Doctype'	, 'thematic'), 'thematic_do_legacy_xhtml_opt'	, 'thematic_theme_opt', 'thematic_opt_section_main');
 		}

--- a/library/tests/test-helpers.php
+++ b/library/tests/test-helpers.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for Theme Options
+ * Tests for Thematic helper functions
  *
  * @package ThematicUnitTests
  */
@@ -8,14 +8,15 @@
 /**
  * @group default
  */
-class TestThemeOptions extends Thematic_UnitTestCase {
+class TestHelpers extends Thematic_UnitTestCase {
 	
 	/**
 	 * The theme options from 1.0
 	 * @var array
 	 */
-    private $pre_upgrade_opt;
-	
+	private $pre_upgrade_opt;
+
+
 	function setUp() {
 		
 		$this->pre_upgrade_opt = array(
@@ -28,9 +29,11 @@ class TestThemeOptions extends Thematic_UnitTestCase {
 		parent::setUp();
 	}
 
+
 	function test_html5_markup_by_default() {
 		$this->assertFalse( thematic_is_legacy_xhtml() );
 	}
+	
 	
 	function test_xhtml_mode_set_by_database() {
 
@@ -40,6 +43,7 @@ class TestThemeOptions extends Thematic_UnitTestCase {
 		
 		$this->delete_theme_option();
 	}
+
 
 	function test_html5_markup_specified_by_theme_support() {
 		
@@ -54,6 +58,7 @@ class TestThemeOptions extends Thematic_UnitTestCase {
 		
 		$this->delete_theme_option();
 	}
+	
 	
 	function test_xhtml_markup_specified_by_theme_support() {
 		

--- a/library/tests/test-thematic.php
+++ b/library/tests/test-thematic.php
@@ -26,4 +26,11 @@ class Thematic_UnitTestCase extends WP_UnitTestCase {
 	    $this->assertTrue( 'Thematic' == wp_get_theme() );
 	}
 
+	function update_theme_option( $options ) {
+		update_option( 'thematic_theme_opt', $options );
+	}
+
+	function delete_theme_option() {
+		delete_option( 'thematic_theme_opt' );
+	}
 }

--- a/library/tests/test-theme-options.php
+++ b/library/tests/test-theme-options.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Tests for Theme Options
+ *
+ * @package ThematicUnitTests
+ */
+
+/**
+ * @group default
+ */
+class TestThemeOptions extends Thematic_UnitTestCase {
+	
+	/**
+	 * The theme options from 1.0
+	 * @var array
+	 */
+    private $pre_upgrade_opt;
+	
+	function setUp() {
+		
+		$this->pre_upgrade_opt = array(
+			'index_insert' 	=> 2,
+			'author_info'  	=> 0,
+			'footer_txt' 	=> 'Powered by [wp-link]. Built on the [theme-link].',
+			'del_legacy_opt'=> 0
+		);
+		
+		parent::setUp();
+	}
+
+	function test_html5_markup_by_default() {
+		$this->assertFalse( thematic_is_legacy_xhtml() );
+	}
+	
+	function test_xhtml_mode_set_by_database() {
+
+		$this->set_xhtml_theme_option();
+		
+		$this->assertTrue( thematic_is_legacy_xhtml() );
+		
+		$this->delete_theme_option();
+	}
+
+	function test_html5_markup_specified_by_theme_support() {
+		
+		$this->set_xhtml_theme_option();
+		$this->assertTrue( thematic_is_legacy_xhtml() );
+		
+		add_theme_support( 'thematic_html5' );
+		$this->assertFalse( thematic_is_legacy_xhtml() );
+		
+		remove_theme_support( 'thematic_html5' );
+		$this->assertTrue( thematic_is_legacy_xhtml() );
+		
+		$this->delete_theme_option();
+	}
+	
+	function test_xhtml_markup_specified_by_theme_support() {
+		
+		$this->assertFalse( thematic_is_legacy_xhtml() );
+		
+		add_theme_support( 'thematic_xhtml' );
+		$this->assertTrue( thematic_is_legacy_xhtml() );
+		
+		remove_theme_support( 'thematic_xhtml' );
+		$this->assertFalse( thematic_is_legacy_xhtml() );
+	}
+	
+	
+	function test_xhtml_mode_set_by_upgrade() {
+
+		// set pre-upgrade options
+		$this->update_theme_option( $this->pre_upgrade_opt );
+		
+		// run upgrade routine - function is hooked to admin_init
+		thematic_opt_init();
+		
+		$this->assertEquals( 'right-sidebar', thematic_get_theme_opt( 'layout' ) );
+		$this->assertTrue( thematic_is_legacy_xhtml() );
+		
+		$this->delete_theme_option();
+	}
+	
+	
+	function set_xhtml_theme_option() {
+		$options = thematic_default_opt();
+		$options['legacy_xhtml'] = 1;
+		
+		$this->update_theme_option( $options );
+	}
+	
+	function update_theme_option( $options ) {
+		update_option( 'thematic_theme_opt', $options );
+	}
+	
+	function delete_theme_option() {
+		delete_option( 'thematic_theme_opt' );
+	}
+	
+	
+
+}

--- a/library/tests/test-theme-options.php
+++ b/library/tests/test-theme-options.php
@@ -88,15 +88,5 @@ class TestThemeOptions extends Thematic_UnitTestCase {
 		
 		$this->update_theme_option( $options );
 	}
-	
-	function update_theme_option( $options ) {
-		update_option( 'thematic_theme_opt', $options );
-	}
-	
-	function delete_theme_option() {
-		delete_option( 'thematic_theme_opt' );
-	}
-	
-	
 
 }

--- a/readme.txt
+++ b/readme.txt
@@ -47,7 +47,7 @@ Fixed: Avoid undefined index error in thematic_browser_class_names(). Props ryan
 Added: Unit tests in /library/tests/ directory.
 Added: File CONTRIBUTING.md with instructions on how to contribute to the project
 Added: Function thematic_is_legacy_xhtml() for checking if legacy mode is active
-Added: Current_theme_supports checks for 'thematic_legacy' for restoring the legacy xhtml doctype
+Added: Current_theme_supports checks for 'thematic_xhtml' for restoring the legacy xhtml doctype
 Added: Theme option checkbox to activate legacy xhtml mode
 Added: Function thematic_doctype() and childtheme_override_doctype()
 Added: Function thematic_html() and childtheme_override_html()


### PR DESCRIPTION
@scottnix @emhr Headsup: Let's hide the checkbox for xhtml mode in the theme options by default. Upgrading child themes will need to use `add_theme_support('thematic_html5')` to get the html5 markup. Checkbox is confusing UI to begin with, and this ensures no accidental switches with potential disastrous results.

I added unit tests and tried with upgrading a couple of themes, but more testing is always better.

See #111 
